### PR TITLE
Added export to newBlock()

### DIFF
--- a/assembly/defaults.ts
+++ b/assembly/defaults.ts
@@ -35,7 +35,7 @@ export function newMockCallWithIO(inputParams: Array<ethereum.EventParam>, outpu
   return new ethereum.Call(defaultAddress, defaultAddress, newBlock(), newTransaction(), inputParams, outputParams);
 }
 
-function newBlock(): ethereum.Block {
+export function newBlock(): ethereum.Block {
     return new ethereum.Block(defaultAddressBytes, defaultAddressBytes, defaultAddressBytes, defaultAddress,
     defaultAddressBytes, defaultAddressBytes, defaultAddressBytes, defaultBigInt, defaultBigInt,
     defaultBigInt, defaultBigInt, defaultBigInt, defaultBigInt, defaultBigInt, defaultBigInt);


### PR DESCRIPTION
This PR adds a simple export for the newBlock method. This may be useful for someone that needs to test blocks and wants to use the default values assigned by this function, without needing to assign all the values over again. In my case this is usefull since im trying to test block handlers in subgraphs, and I need to create multiple test blocks.